### PR TITLE
Link example OpenHands transcript in README

### DIFF
--- a/openhands-conversation-export/README.md
+++ b/openhands-conversation-export/README.md
@@ -32,5 +32,5 @@ Notes:
 ## Example output
 
 - Example transcript (rendered markdown):
-  - [Roasted PR Review: Build Project & Run Tests](./conversations/2c6ec633e00c4c5da99601de500e5752.md)
+  - [Discussion on WS reliability and /events source of truth](./conversations/2c6ec633e00c4c5da99601de500e5752.md)
 

--- a/openhands-conversation-export/README.md
+++ b/openhands-conversation-export/README.md
@@ -32,5 +32,5 @@ Notes:
 ## Example output
 
 - Example transcript (rendered markdown):
-  - [`conversations/2c6ec633e00c4c5da99601de500e5752.md`](./conversations/2c6ec633e00c4c5da99601de500e5752.md)
+  - [Roasted PR Review: Build Project & Run Tests](./conversations/2c6ec633e00c4c5da99601de500e5752.md)
 

--- a/openhands-conversation-export/README.md
+++ b/openhands-conversation-export/README.md
@@ -28,3 +28,9 @@ python openhands-conversation-export/scripts/render_markdown.py \
 Notes:
 - The exporter will automatically fall back to the per-conversation runtime URL (requires `session_api_key`) if `app.all-hands.dev` returns errors.
 - Tool calls / tool results are rendered inside collapsed `<details>` blocks.
+
+## Example output
+
+- Example transcript (rendered markdown):
+  - [`conversations/2c6ec633e00c4c5da99601de500e5752.md`](./conversations/2c6ec633e00c4c5da99601de500e5752.md)
+


### PR DESCRIPTION
Adds a clickable link in `openhands-conversation-export/README.md` to the committed example transcript markdown so it renders directly on GitHub.

Example: `openhands-conversation-export/conversations/2c6ec633e00c4c5da99601de500e5752.md`

@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)