### PR TITLE
feat(v1-client): OpenHands V1 API Client with Phase 1 Read Operations

### DIFF
--- a/openhands-api-client-v1/README.md
+++ b/openhands-api-client-v1/README.md
@@ -2,31 +2,127 @@
 
 A Python client for the OpenHands Cloud API V1.
 
-> **Work in Progress**: This client is being developed. See [SCRATCHPAD.md](SCRATCHPAD.md) for development notes.
+## V1 Architecture
+
+V1 uses a **two-tier architecture**:
+
+1. **App Server** (`/api/v1/...`) - Orchestrates conversations and sandboxes
+2. **Agent Server** (inside sandbox) - Executes commands, file operations
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  App Server (app.all-hands.dev/api/v1/)                     │
+│  - Conversation lifecycle (create, list, delete)            │
+│  - Sandbox management (start, pause, resume)                │
+│  - Event storage and retrieval                              │
+│  - User info                                                │
+└─────────────────────────────────────────────────────────────┘
+                              │
+                              │ exposed_urls['AGENT_SERVER']
+                              ▼
+┌─────────────────────────────────────────────────────────────┐
+│  Agent Server (dynamic URL per sandbox)                     │
+│  - File upload/download                                     │
+│  - Bash command execution                                   │
+│  - VS Code access                                           │
+│  - Git operations                                           │
+└─────────────────────────────────────────────────────────────┘
+```
 
 ## V1 vs V0
 
-V1 introduces significant architectural changes:
-
 | Feature | V0 (Legacy) | V1 (Current) |
 |---------|-------------|--------------|
-| Conversations | Short IDs | UUIDs |
-| Runtime | Direct URLs | Sandboxes with exposed_urls |
+| Conversations | Short alphanumeric IDs | UUIDs (32 hex chars) |
+| Runtime | Direct runtime URLs | Sandboxes with `exposed_urls` |
 | Trajectory | JSON endpoint | Zip file download |
 | Events | Pagination by ID | Search with filters |
+| Status | Deprecated (removal: April 2026) | Current |
+
+## Quick Start
+
+```bash
+cd openhands-api-client-v1
+python3 -m venv .venv
+source .venv/bin/activate
+pip install httpx
+
+# Set your API key
+export OPENHANDS_API_KEY="sk-oh-your-key-here"
+
+# Run tests (each makes ONE API call)
+python scripts/cloud_api_v1.py search_conversations
+python scripts/cloud_api_v1.py count_conversations
+python scripts/cloud_api_v1.py get_user
+python scripts/cloud_api_v1.py search_sandboxes
+python scripts/cloud_api_v1.py search_events <conversation_id>
+```
 
 ## Files
 
-- `scripts/cloud_api.py` - V1 API client (in development)
-- `SCRATCHPAD.md` - Development notes and API documentation
+- `scripts/cloud_api_v1.py` - V1 API client
+- `SCRATCHPAD.md` - Development notes and detailed API documentation
 
 ## Environment Variables
 
 | Variable | Required | Description |
 |----------|----------|-------------|
-| `OPENHANDS_API_KEY` | Yes | Your OpenHands Cloud API key |
+| `OPENHANDS_API_KEY` | Yes | Your OpenHands Cloud API key (prefix: `sk-oh-`) |
 | `OPENHANDS_APP_BASE` | No | Override base URL (default: `https://app.all-hands.dev`) |
+
+## API Endpoints
+
+### App Conversations (`/api/v1/app-conversations/`)
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| GET | `/search` | List conversations with filters |
+| GET | `/count` | Count conversations |
+| GET | `/{id}` | Get conversation details |
+| POST | `/` | Start new conversation |
+| PATCH | `/{id}` | Update conversation |
+| DELETE | `/{id}` | Delete conversation |
+| GET | `/{id}/skills` | Get loaded skills |
+| GET | `/{id}/download` | Download trajectory (zip) |
+
+### Sandboxes (`/api/v1/sandboxes/`)
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| GET | `/search` | List sandboxes |
+| GET | `?id=...` | Batch get sandboxes |
+| POST | `/` | Start new sandbox |
+| POST | `/{id}/pause` | Pause sandbox |
+| POST | `/{id}/resume` | Resume sandbox |
+| DELETE | `/{id}` | Delete sandbox |
+
+### Events (`/api/v1/conversation/{id}/events/`)
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| GET | `/search` | Search events with filters |
+| GET | `/count` | Count events |
+| GET | `?id=...` | Batch get events |
+
+### Users (`/api/v1/users/`)
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| GET | `/me` | Get current user info |
+
+## Authentication
+
+All endpoints use Bearer token authentication:
+
+```
+Authorization: Bearer sk-oh-your-api-key
+```
+
+Same API key works for both V0 and V1 endpoints.
 
 ## Status
 
-🚧 Under construction - see SCRATCHPAD.md for progress.
+- ✅ Phase 1: Read operations (complete)
+- 🚧 Phase 2: Write operations (in progress)
+- 📋 Phase 3: Agent Server integration
+- 📋 Phase 4: Utilities

--- a/openhands-api-client-v1/scripts/cloud_api_v1.py
+++ b/openhands-api-client-v1/scripts/cloud_api_v1.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+"""
+OpenHands Cloud API V1 Client
+
+SAFETY: This script is designed to make minimal API calls.
+- Use limit=1 for list operations during testing
+- No loops that hit the API
+- Each function makes at most ONE API call
+"""
+
+import os
+import json
+import httpx
+from datetime import datetime
+
+# Configuration
+API_KEY = os.environ.get("OPENHANDS_API_KEY")
+BASE_URL = os.environ.get("OPENHANDS_APP_BASE", "https://app.all-hands.dev")
+API_V1_URL = f"{BASE_URL}/api/v1"
+
+def get_headers():
+    """Get headers for API requests."""
+    return {
+        "Authorization": f"Bearer {API_KEY}",
+        "Content-Type": "application/json",
+    }
+
+def pretty_print(data, title=None):
+    """Pretty print JSON data."""
+    if title:
+        print(f"\n{'='*60}")
+        print(f" {title}")
+        print(f"{'='*60}")
+    print(json.dumps(data, indent=2, default=str))
+
+# =============================================================================
+# App Conversations
+# =============================================================================
+
+def search_app_conversations(limit: int = 1):
+    """Search app conversations. ONE API call."""
+    url = f"{API_V1_URL}/app-conversations/search"
+    params = {"limit": limit}
+    
+    print(f"[API CALL] GET {url} params={params}")
+    response = httpx.get(url, headers=get_headers(), params=params, timeout=30)
+    response.raise_for_status()
+    return response.json()
+
+def get_app_conversation(conversation_id: str):
+    """Get a single app conversation by ID. ONE API call."""
+    url = f"{API_V1_URL}/app-conversations/{conversation_id}"
+    
+    print(f"[API CALL] GET {url}")
+    response = httpx.get(url, headers=get_headers(), timeout=30)
+    response.raise_for_status()
+    return response.json()
+
+def count_app_conversations():
+    """Count all app conversations. ONE API call."""
+    url = f"{API_V1_URL}/app-conversations/count"
+    
+    print(f"[API CALL] GET {url}")
+    response = httpx.get(url, headers=get_headers(), timeout=30)
+    response.raise_for_status()
+    return response.json()
+
+# =============================================================================
+# Sandboxes
+# =============================================================================
+
+def search_sandboxes(limit: int = 1):
+    """Search sandboxes. ONE API call."""
+    url = f"{API_V1_URL}/sandboxes/search"
+    params = {"limit": limit}
+    
+    print(f"[API CALL] GET {url} params={params}")
+    response = httpx.get(url, headers=get_headers(), params=params, timeout=30)
+    response.raise_for_status()
+    return response.json()
+
+# =============================================================================
+# Sandbox Specs
+# =============================================================================
+
+def search_sandbox_specs(limit: int = 1):
+    """Search sandbox specs. ONE API call."""
+    url = f"{API_V1_URL}/sandbox-specs/search"
+    params = {"limit": limit}
+    
+    print(f"[API CALL] GET {url} params={params}")
+    response = httpx.get(url, headers=get_headers(), params=params, timeout=30)
+    response.raise_for_status()
+    return response.json()
+
+# =============================================================================
+# Events
+# =============================================================================
+
+def search_events(conversation_id: str, limit: int = 1):
+    """Search events for a conversation. ONE API call."""
+    url = f"{API_V1_URL}/conversation/{conversation_id}/events/search"
+    params = {"limit": limit}
+    
+    print(f"[API CALL] GET {url} params={params}")
+    response = httpx.get(url, headers=get_headers(), params=params, timeout=30)
+    response.raise_for_status()
+    return response.json()
+
+def count_events(conversation_id: str):
+    """Count events for a conversation. ONE API call."""
+    url = f"{API_V1_URL}/conversation/{conversation_id}/events/count"
+    
+    print(f"[API CALL] GET {url}")
+    response = httpx.get(url, headers=get_headers(), timeout=30)
+    response.raise_for_status()
+    return response.json()
+
+# =============================================================================
+# Users
+# =============================================================================
+
+def get_current_user():
+    """Get current authenticated user. ONE API call."""
+    url = f"{API_V1_URL}/users/me"
+    
+    print(f"[API CALL] GET {url}")
+    response = httpx.get(url, headers=get_headers(), timeout=30)
+    response.raise_for_status()
+    return response.json()
+
+
+# =============================================================================
+# Main - Test ONE endpoint at a time
+# =============================================================================
+
+def run_test(name: str, func, *args, **kwargs):
+    """Run a single test with error handling."""
+    print(f"\n{'='*60}")
+    print(f" TEST: {name}")
+    print(f"{'='*60}")
+    try:
+        result = func(*args, **kwargs)
+        print(json.dumps(result, indent=2, default=str))
+        return result
+    except httpx.HTTPStatusError as e:
+        print(f"HTTP Error: {e.response.status_code}")
+        print(f"Response: {e.response.text[:500]}")
+        return None
+    except Exception as e:
+        print(f"Error: {e}")
+        return None
+
+
+if __name__ == "__main__":
+    import sys
+    
+    if not API_KEY:
+        print("ERROR: Set OPENHANDS_API_KEY environment variable")
+        exit(1)
+    
+    print(f"Base URL: {BASE_URL}")
+    print(f"API Key: {API_KEY[:10]}...{API_KEY[-4:]}")
+    
+    # Usage: python cloud_api_v1.py [test_name] [conversation_id]
+    # Tests: search_conversations, count_conversations, get_conversation,
+    #        search_sandboxes, search_sandbox_specs, get_user,
+    #        search_events, count_events
+    
+    test_name = sys.argv[1] if len(sys.argv) > 1 else "search_conversations"
+    conv_id = sys.argv[2] if len(sys.argv) > 2 else None
+    
+    # Each test makes exactly ONE API call
+    if test_name == "search_conversations":
+        run_test("Search App Conversations (limit=1)", search_app_conversations, limit=1)
+    
+    elif test_name == "count_conversations":
+        run_test("Count App Conversations", count_app_conversations)
+    
+    elif test_name == "get_conversation":
+        if not conv_id:
+            print("ERROR: Provide conversation_id as second argument")
+            exit(1)
+        run_test(f"Get App Conversation {conv_id}", get_app_conversation, conv_id)
+    
+    elif test_name == "search_sandboxes":
+        run_test("Search Sandboxes (limit=1)", search_sandboxes, limit=1)
+    
+    elif test_name == "search_sandbox_specs":
+        run_test("Search Sandbox Specs (limit=1)", search_sandbox_specs, limit=1)
+    
+    elif test_name == "get_user":
+        run_test("Get Current User", get_current_user)
+    
+    elif test_name == "search_events":
+        if not conv_id:
+            print("ERROR: Provide conversation_id as second argument")
+            exit(1)
+        run_test(f"Search Events for {conv_id} (limit=1)", search_events, conv_id, limit=1)
+    
+    elif test_name == "count_events":
+        if not conv_id:
+            print("ERROR: Provide conversation_id as second argument")
+            exit(1)
+        run_test(f"Count Events for {conv_id}", count_events, conv_id)
+    
+    else:
+        print(f"Unknown test: {test_name}")
+        print("Available: search_conversations, count_conversations, get_conversation,")
+        print("           search_sandboxes, search_sandbox_specs, get_user,")
+        print("           search_events, count_events")

--- a/openhands-api-client-v1/scripts/cloud_api_v1.py
+++ b/openhands-api-client-v1/scripts/cloud_api_v1.py
@@ -20,6 +20,8 @@ API_V1_URL = f"{BASE_URL}/api/v1"
 
 def get_headers():
     """Get headers for API requests."""
+    if not API_KEY:
+        raise ValueError("OPENHANDS_API_KEY environment variable is not set")
     return {
         "Authorization": f"Bearer {API_KEY}",
         "Content-Type": "application/json",
@@ -145,7 +147,7 @@ def run_test(name: str, func, *args, **kwargs):
         return result
     except httpx.HTTPStatusError as e:
         print(f"HTTP Error: {e.response.status_code}")
-        print(f"Response: {e.response.text[:500]}")
+        print(f"Response: {e.response.text}")
         return None
     except Exception as e:
         print(f"Error: {e}")


### PR DESCRIPTION
## Summary

Add a Python client for the OpenHands Cloud API V1 with complete documentation and tested read operations.

## Changes

### New Files
- `openhands-api-client-v1/scripts/cloud_api_v1.py` - V1 API client with safety guards

### Updated Documentation  
- `openhands-api-client-v1/README.md` - Complete V1 architecture docs and endpoint reference
- `openhands-api-client-v1/SCRATCHPAD.md` - Verified findings from API testing

## V1 Architecture

V1 uses a two-tier architecture:
1. **App Server** (`/api/v1/...`) - Orchestrates conversations and sandboxes
2. **Agent Server** (inside sandbox) - Executes commands, file operations

## Tested Endpoints

| Endpoint | Status |
|----------|--------|
| `GET /api/v1/app-conversations/search` | ✅ |
| `GET /api/v1/app-conversations/count` | ✅ |
| `GET /api/v1/sandboxes/search` | ✅ |
| `GET /api/v1/conversati| `GET /api/v1/conversati| `GET /api/v1/conversati| `GET /api/v1/conversati| `GET /api/v1/conversati| `GET /api/v1/conversati| `GET /api/v1/conOPEN| `GET /api/v1/conversati| `GET /api/v1/conversati| `GET /api/v1/conversati| `GET /api/v1/conversat
- Each test makes exactly ONE API call
- List operations use `limit=1` by default
- No loops that hit the API

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Restructured main README with a new Directories table and explicit Structure guidance.
  * Updated V0 client docs to mark it as legacy with migration guidance to V1.
  * Added full V1 client documentation (architecture, quick start, endpoints, auth, status).
  * Added V1 architectural reference/scratchpad with implementation plan and testing notes.

* **New Features**
  * Added a minimal V1 CLI demo/test script for one-off API interactions and simple output.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->