### PR TITLE
Document app/agent event endpoints in v1 client

### DIFF
--- a/openhands-api-client-v1/README.md
+++ b/openhands-api-client-v1/README.md
@@ -22,6 +22,7 @@ V1 uses a **two-tier architecture**:
                               ▼
 ┌─────────────────────────────────────────────────────────────┐
 │  Agent Server (dynamic URL per sandbox)                     │
+│  - Conversation event search/count                          │
 │  - File upload/download                                     │
 │  - Bash command execution                                   │
 │  - VS Code access                                           │
@@ -56,6 +57,9 @@ python scripts/cloud_api_v1.py count_conversations
 python scripts/cloud_api_v1.py get_user
 python scripts/cloud_api_v1.py search_sandboxes
 python scripts/cloud_api_v1.py search_events <conversation_id>
+python scripts/cloud_api_v1.py agent_search_events <agent_server_url> <session_api_key> <conversation_id>
+python scripts/cloud_api_v1.py agent_count_events <agent_server_url> <session_api_key> <conversation_id>
+
 ```
 
 ## Files
@@ -96,13 +100,22 @@ python scripts/cloud_api_v1.py search_events <conversation_id>
 | POST | `/{id}/resume` | Resume sandbox |
 | DELETE | `/{id}` | Delete sandbox |
 
-### Events (`/api/v1/conversation/{id}/events/`)
+### Events (App Server) (`/api/v1/conversation/{id}/events/`)
 
 | Method | Endpoint | Description |
 |--------|----------|-------------|
 | GET | `/search` | Search events with filters |
 | GET | `/count` | Count events |
 | GET | `?id=...` | Batch get events |
+
+### Events (Agent Server) (`/api/conversations/{id}/events/`)
+
+Use the sandbox `AGENT_SERVER` URL and the `X-Session-API-Key` header.
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| GET | `/search` | Search events with filters |
+| GET | `/count` | Count events |
 
 ### Users (`/api/v1/users/`)
 
@@ -112,13 +125,19 @@ python scripts/cloud_api_v1.py search_events <conversation_id>
 
 ## Authentication
 
-All endpoints use Bearer token authentication:
+App Server endpoints use Bearer token authentication:
 
 ```
 Authorization: Bearer sk-oh-your-api-key
 ```
 
-Same API key works for both V0 and V1 endpoints.
+Agent Server endpoints use the session API key and the `X-Session-API-Key` header:
+
+```
+X-Session-API-Key: <session_api_key>
+```
+
+Same API key works for both V0 and V1 app server endpoints.
 
 ## Status
 

--- a/openhands-api-client-v1/SCRATCHPAD.md
+++ b/openhands-api-client-v1/SCRATCHPAD.md
@@ -24,7 +24,7 @@ V1 introduces a new architecture with two distinct servers:
 |--------|----|----|
 | Conversation IDs | Short alphanumeric | UUIDs (32 hex chars) |
 | Runtime | Direct runtime URLs | Sandboxes with exposed_urls |
-| Events | `/api/conversations/{id}/events` | `/api/v1/conversation/{id}/events/search` |
+| Events | `/api/conversations/{id}/events` | App server: `/api/v1/conversation/{id}/events/search` (agent server: `/api/conversations/{id}/events/...`) |
 | Start conversation | Create + separate start | Single `POST /api/v1/app-conversations` |
 | Trajectory | `/api/conversations/{id}/trajectory` | `/api/v1/app-conversations/{id}/download` (returns zip) |
 
@@ -66,6 +66,8 @@ V1 introduces a new architecture with two distinct servers:
 ## Agent Server Endpoints (within sandbox)
 
 These run at the `AGENT_SERVER` URL from sandbox's `exposed_urls`:
+Requests require the `X-Session-API-Key` header for authentication.
+
 
 | Endpoint | Method | Description |
 |----------|--------|-------------|

--- a/openhands-api-client-v1/scripts/cloud_api_v1.py
+++ b/openhands-api-client-v1/scripts/cloud_api_v1.py
@@ -468,7 +468,7 @@ if __name__ == "__main__":
     elif test_name == "agent_count_events":
         # Usage: agent_count_events <agent_server_url> <session_api_key> <conversation_id>
         if len(sys.argv) < 5:
-            print("ERROR: agent_count_events <agent_server_url> <session_api_key> <conversation_id>")
+            print(f"ERROR: {test_name} <agent_server_url> <session_api_key> <conversation_id>")
             exit(1)
         agent_url = sys.argv[2]
         session_key = sys.argv[3]

--- a/openhands-api-client-v1/scripts/cloud_api_v1.py
+++ b/openhands-api-client-v1/scripts/cloud_api_v1.py
@@ -451,7 +451,7 @@ if __name__ == "__main__":
     elif test_name == "agent_search_events":
         # Usage: agent_search_events <agent_server_url> <session_api_key> <conversation_id>
         if len(sys.argv) < 5:
-            print("ERROR: agent_search_events <agent_server_url> <session_api_key> <conversation_id>")
+            print(f"ERROR: {test_name} <agent_server_url> <session_api_key> <conversation_id>")
             exit(1)
         agent_url = sys.argv[2]
         session_key = sys.argv[3]

--- a/openhands-api-client-v1/scripts/cloud_api_v1.py
+++ b/openhands-api-client-v1/scripts/cloud_api_v1.py
@@ -127,6 +127,42 @@ def count_events(conversation_id: str):
     return response.json()
 
 # =============================================================================
+# Agent Server Events
+# =============================================================================
+
+def agent_search_events(
+    agent_server_url: str,
+    session_api_key: str,
+    conversation_id: str,
+    limit: int = 1,
+):
+    """Search events for a conversation via agent server. ONE API call."""
+    url = f"{agent_server_url}/api/conversations/{conversation_id}/events/search"
+    params = {"limit": limit}
+    headers = get_agent_server_headers(session_api_key)
+
+    print(f"[API CALL] GET {url} params={params}")
+    response = httpx.get(url, headers=headers, params=params, timeout=30)
+    response.raise_for_status()
+    return response.json()
+
+
+def agent_count_events(
+    agent_server_url: str,
+    session_api_key: str,
+    conversation_id: str,
+):
+    """Count events for a conversation via agent server. ONE API call."""
+    url = f"{agent_server_url}/api/conversations/{conversation_id}/events/count"
+    headers = get_agent_server_headers(session_api_key)
+
+    print(f"[API CALL] GET {url}")
+    response = httpx.get(url, headers=headers, timeout=30)
+    response.raise_for_status()
+    return response.json()
+
+
+# =============================================================================
 # Users
 # =============================================================================
 
@@ -330,6 +366,8 @@ if __name__ == "__main__":
     # Read tests: search_conversations, count_conversations, get_conversation,
     #             search_sandboxes, search_sandbox_specs, get_user,
     #             search_events, count_events
+    # Agent server tests: agent_search_events, agent_count_events, agent_bash,
+    #                     agent_download, agent_upload
     # Write tests: start_conversation, resume_sandbox, pause_sandbox, download_trajectory
     
     test_name = sys.argv[1] if len(sys.argv) > 1 else "search_conversations"
@@ -410,6 +448,40 @@ if __name__ == "__main__":
     
     # === Agent Server Operations (Phase 3) ===
     # These require: agent_server_url and session_api_key from a RUNNING sandbox
+    elif test_name == "agent_search_events":
+        # Usage: agent_search_events <agent_server_url> <session_api_key> <conversation_id>
+        if len(sys.argv) < 5:
+            print("ERROR: agent_search_events <agent_server_url> <session_api_key> <conversation_id>")
+            exit(1)
+        agent_url = sys.argv[2]
+        session_key = sys.argv[3]
+        conversation_id = sys.argv[4]
+        run_test(
+            f"Agent Search Events {conversation_id} (limit=5)",
+            agent_search_events,
+            agent_url,
+            session_key,
+            conversation_id,
+            limit=5,
+        )
+
+    elif test_name == "agent_count_events":
+        # Usage: agent_count_events <agent_server_url> <session_api_key> <conversation_id>
+        if len(sys.argv) < 5:
+            print("ERROR: agent_count_events <agent_server_url> <session_api_key> <conversation_id>")
+            exit(1)
+        agent_url = sys.argv[2]
+        session_key = sys.argv[3]
+        conversation_id = sys.argv[4]
+        run_test(
+            f"Agent Count Events {conversation_id}",
+            agent_count_events,
+            agent_url,
+            session_key,
+            conversation_id,
+        )
+
+
     elif test_name == "agent_bash":
         # Usage: agent_bash <agent_server_url> <session_api_key> <command>
         if len(sys.argv) < 5:
@@ -462,6 +534,8 @@ if __name__ == "__main__":
         print("  download_trajectory <conv_id> [output_file]")
         print("  get_start_task <task_id>")
         print("\nAgent Server Operations (Phase 3):")
+        print("  agent_search_events <agent_server_url> <session_api_key> <conversation_id>")
+        print("  agent_count_events <agent_server_url> <session_api_key> <conversation_id>")
         print("  agent_bash <agent_server_url> <session_api_key> <command>")
         print("  agent_download <agent_server_url> <session_api_key> <path>")
         print("  agent_upload <agent_server_url> <session_api_key> <path> <content>")


### PR DESCRIPTION
## Summary
- document both app-server and agent-server event endpoints in the V1 README/SCRATCHPAD
- clarify auth headers and add agent event examples
- add agent event search/count helpers and CLI dispatch paths

## Testing
- not run (docs/client updates only)


@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added two new CLI commands for Agent Server: search and count conversation events

* **Documentation**
  * Enhanced architecture documentation with Agent Server capabilities and operations
  * Clarified authentication methods and required headers for Agent Server endpoints
  * Updated endpoint references to distinguish between App Server and Agent Server paths

<!-- end of auto-generated comment: release notes by coderabbit.ai -->